### PR TITLE
Unify token authn for consent apps

### DIFF
--- a/consent-self-service/acp.go
+++ b/consent-self-service/acp.go
@@ -35,7 +35,7 @@ func NewAcpClient(config Config) (AcpClient, error) {
 		err       error
 	)
 
-	parts := strings.Split(config.TokenURL.Path, "/")
+	parts := strings.Split(config.SystemTokenURL.Path, "/")
 	if len(parts) == 0 {
 		return acpClient, errors.New("can't get tenant from issuer url")
 	}
@@ -46,16 +46,17 @@ func NewAcpClient(config Config) (AcpClient, error) {
 	}
 
 	cc := clientcredentials.Config{
-		ClientID:  config.ClientID,
-		Scopes:    []string{"manage_openbanking_consents"},
-		TokenURL:  config.TokenURL.String(),
-		AuthStyle: oauth2.AuthStyleInParams,
+		ClientID:     config.SystemClientID,
+		ClientSecret: config.SystemClientSecret,
+		Scopes:       []string{"manage_openbanking_consents"},
+		TokenURL:     config.SystemTokenURL.String(),
+		AuthStyle:    oauth2.AuthStyleInParams,
 	}
 
 	acpClient.client = client.New(httptransport.NewWithClient(
-		config.TokenURL.Host,
+		config.SystemTokenURL.Host,
 		"/",
-		[]string{config.TokenURL.Scheme},
+		[]string{config.SystemTokenURL.Scheme},
 		cc.Client(context.WithValue(context.Background(), oauth2.HTTPClient, hc)),
 	), nil)
 
@@ -125,7 +126,7 @@ func NewAcpIntrospectClient(config Config) (AcpIntrospectClient, error) {
 	acpClient.client = client.New(httptransport.NewWithClient(
 		config.IntrospectTokenURL.Host,
 		"/",
-		[]string{config.TokenURL.Scheme},
+		[]string{config.IntrospectTokenURL.Scheme},
 		cc.Client(context.WithValue(context.Background(), oauth2.HTTPClient, hc)),
 	), nil)
 

--- a/consent-self-service/main.go
+++ b/consent-self-service/main.go
@@ -13,8 +13,9 @@ import (
 )
 
 type Config struct {
-	ClientID                    string        `env:"CLIENT_ID,required"`
-	TokenURL                    *url.URL      `env:"TOKEN_URL,required"`
+	SystemClientID              string        `env:"SYSTEM_CLIENT_ID,required"`
+	SystemClientSecret          string        `env:"SYSTEM_CLIENT_SECRET,required"`
+	SystemTokenURL              *url.URL      `env:"SYSTEM_TOKEN_URL,required"`
 	Timeout                     time.Duration `env:"TIMEOUT" envDefault:"5s"`
 	RootCA                      string        `env:"ROOT_CA"`
 	CertFile                    string        `env:"CERT_FILE,required"`

--- a/data/seed.yaml
+++ b/data/seed.yaml
@@ -1493,7 +1493,7 @@ clients:
   tenant_id: default
   tls_client_auth_subject_dn: CN=cid2.authorization.cloudentity.com,OU=Authorization,O=Cloudentity,L=Seattle,ST=Washinghton,C=US
   tls_client_certificate_bound_access_tokens: true
-  token_endpoint_auth_method: tls_client_auth
+  token_endpoint_auth_method: client_secret_post
   token_endpoint_auth_signing_alg: none
   userinfo_signed_response_alg: none
 - application_type: web

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -65,9 +65,9 @@ services:
       - ./data/bank_cert.pem:/bank_cert.pem
       - ./data/bank_key.pem:/bank_key.pem
     environment:
-      - CLIENT_ID=buc3b1hhuc714r78env0
-      - CLIENT_SECRET=PBV7q0akoP603rZbU0EFdxbhZ-djxF7FIVwyKaLnBYU
-      - TOKEN_URL=https://acp:8443/default/system/oauth2/token
+      - SYSTEM_CLIENT_ID=buc3b1hhuc714r78env0
+      - SYSTEM_CLIENT_SECRET=PBV7q0akoP603rZbU0EFdxbhZ-djxF7FIVwyKaLnBYU
+      - SYSTEM_TOKEN_URL=https://acp:8443/default/system/oauth2/token
       - CERT_FILE=/bank_cert.pem
       - KEY_FILE=/bank_key.pem
       - ROOT_CA=/ca.pem


### PR DESCRIPTION
- use client_secret_post for consent-self-service (the same as for consent-admin)
- unify consent apps env variables